### PR TITLE
Retry API requests on timeouts (HTTP status 408)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ LINODE_TOKEN        Linode API token environment variable, default: nil
 :sudo               use sudo, default: True
 :port               ssh port, default: 22
 :label              set the hostname and linode label
-:api_retries        how many times to retry API calls on timeouts, default: 3
+:api_retries        how many times to retry API calls on timeouts or rate limits, default: 5
 ```
 
 ## <a name="usage"></a> Usage

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ LINODE_TOKEN        Linode API token environment variable, default: nil
 :sudo               use sudo, default: True
 :port               ssh port, default: 22
 :label              set the hostname and linode label
+:api_retries        how many times to retry API calls on timeouts, default: 3
 ```
 
 ## <a name="usage"></a> Usage

--- a/kitchen-linode.gemspec
+++ b/kitchen-linode.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'test-kitchen', '~> 1.4'
   spec.add_dependency 'fog-linode', '~> 0.0.1.rc2'
+  spec.add_dependency 'retryable', '>= 2.0', '< 4.0'
 
   spec.add_development_dependency 'bundler'
   spec.add_development_dependency 'rake', '~> 10.4'

--- a/lib/kitchen/driver/linode.rb
+++ b/lib/kitchen/driver/linode.rb
@@ -18,6 +18,7 @@
 
 require 'kitchen'
 require 'fog/linode'
+require 'retryable'
 require_relative 'linode_version'
 
 module Kitchen
@@ -29,7 +30,7 @@ module Kitchen
     class Linode < Kitchen::Driver::Base
       kitchen_driver_api_version 2
       plugin_version Kitchen::Driver::LINODE_VERSION
-      
+
       default_config :username, 'root'
       default_config :password, nil
       default_config :label, nil
@@ -38,10 +39,11 @@ module Kitchen
       default_config :region, 'us-east'
       default_config :type, 'g6-nanode-1'
       default_config :kernel, 'linode/grub2'
-      
+      default_config :api_retries, 3
+
       default_config :sudo, true
       default_config :ssh_timeout, 600
-      
+
       default_config :private_key_path do
         %w(id_rsa).map do |k|
           f = File.expand_path("~/.ssh/#{k}")
@@ -51,28 +53,40 @@ module Kitchen
       default_config :public_key_path do |driver|
         driver[:private_key_path] + '.pub' if driver[:private_key_path]
       end
-      
+
       default_config :linode_token, ENV['LINODE_TOKEN']
-      
+
       required_config :linode_token
       required_config :private_key_path
       required_config :public_key_path
+
+      def initialize(config)
+        super
+        log_method = lambda do |retries, exception|
+          warn "[Attempt ##{retries}] Retrying because [#{exception.class} - #{exception.message}]"
+        end
+        Retryable.configure do |retry_config|
+          retry_config.log_method   = log_method
+          retry_config.on           = Excon::Error::RequestTimeout
+          retry_config.tries        = config[:api_retries]
+        end
+      end
 
       def create(state)
         # create and boot server
         config_hostname
         config_label
         set_password
-        
+
         if state[:linode_id]
           info "#{config[:label]} (#{state[:linode_id]}) already exists."
           return
         end
-        
+
         info("Creating Linode - #{config[:label]}")
-        
+
         server = create_server
-        
+
         # assign the machine id for reference in other commands
         state[:linode_id] = server.id
         state[:hostname] = server.ipv4[0]
@@ -87,23 +101,29 @@ module Kitchen
 
       def destroy(state)
         return if state[:linode_id].nil?
-        server = compute.servers.get(state[:linode_id])
-
-        server.destroy
-
+        server = nil
+        Retryable.retryable do
+          server = compute.servers.get(state[:linode_id])
+        end
+        Retryable.retryable do
+          server.destroy
+        end
         info("Linode <#{state[:linode_id]}> destroyed.")
         state.delete(:linode_id)
         state.delete(:pub_ip)
       end
-      
+
       private
-      
+
       def compute
         Fog::Compute.new(provider: :linode, linode_token: config[:linode_token])
       end
-      
+
       def get_region
-        region = compute.regions.find { |region| region.id == config[:region] }
+        region = nil
+        Retryable.retryable do
+          region = compute.regions.find { |region| region.id == config[:region] }
+        end
 
         if region.nil?
           fail(UserError, "No match for region: #{config[:region]}")
@@ -111,9 +131,12 @@ module Kitchen
         info "Got region: #{region.id}..."
         return region.id
       end
-      
+
       def get_type
-        type = compute.types.find { |type| type.id == config[:type] }
+        type = nil
+        Retryable.retryable do
+          type = compute.types.find { |type| type.id == config[:type] }
+        end
 
         if type.nil?
           fail(UserError, "No match for type: #{config[:type]}")
@@ -121,12 +144,16 @@ module Kitchen
         info "Got type: #{type.id}..."
         return type.id
       end
-      
+
       def get_image
         if config[:image].nil?
-          image = compute.images.find { |image| image.id == instance.platform.name }
+          image_id = instance.platform.name
         else
-          image = compute.images.find { |image| image.id == config[:image] }
+          image_id = config[:image]
+        end
+        image = nil
+        Retryable.retryable do
+          image = compute.images.find { |image| image.id == image_id }
         end
 
         if image.nil?
@@ -135,9 +162,12 @@ module Kitchen
         info "Got image: #{image.id}..."
         return image.id
       end
-      
+
       def get_kernel
-        kernel = compute.kernels.find { |kernel| kernel.id == config[:kernel] }
+        kernel = nil
+        Retryable.retryable do
+          kernel = compute.kernels.find { |kernel| kernel.id == config[:kernel] }
+        end
 
         if kernel.nil?
           fail(UserError, "No match for kernel: #{config[:kernel]}")
@@ -145,25 +175,27 @@ module Kitchen
         info "Got kernel: #{kernel.id}..."
         return kernel.id
       end
-      
+
       def create_server
         region = get_region
         type = get_type
         image = get_image
         kernel = get_kernel
-        
-        # submit new linode request
-        compute.servers.create(
-          :region => region,
-          :type => type,
-          :label => config[:label],
-          :image => image,
-          :kernel => kernel,
-          :username => config[:username],
-          :root_pass => config[:password]
-        )
+
+        Retryable.retryable do
+          # submit new linode request
+          compute.servers.create(
+            :region => region,
+            :type => type,
+            :label => config[:label],
+            :image => image,
+            :kernel => kernel,
+            :username => config[:username],
+            :root_pass => config[:password]
+          )
+        end
       end
-      
+
       def setup_ssh(state)
         set_ssh_keys
         state[:ssh_key] = config[:private_key_path]
@@ -204,7 +236,7 @@ module Kitchen
         end
         info "Done setting up SSH access."
       end
-      
+
       # Set the proper server name in the config
       def config_label
         if config[:label]
@@ -222,7 +254,7 @@ module Kitchen
           end
           config[:label] = "kitchen-#{jobname}-#{instance.name}-#{Time.now.to_i.to_s}".tr(" /", "_")
         end
-        
+
         # cut to fit Linode 32 character maximum
         if config[:label].is_a?(String) && config[:label].size >= 32
           config[:label] = "#{config[:label][0..29]}#{rand(10..99)}"
@@ -239,14 +271,14 @@ module Kitchen
           end
         end
       end
-      
+
       # ensure a password is set
       def set_password
         if config[:password].nil?
           config[:password] = [*('a'..'z'),*('A'..'Z'),*('0'..'9')].sample(15).join
         end
       end
-      
+
       # set ssh keys
       def set_ssh_keys
         if config[:private_key_path]

--- a/lib/kitchen/driver/linode.rb
+++ b/lib/kitchen/driver/linode.rb
@@ -63,7 +63,7 @@ module Kitchen
       def initialize(config)
         super
         log_method = lambda do |retries, exception|
-          warn "[Attempt ##{retries}] Retrying because [#{exception.class} - #{exception.message}]"
+          warn("[Attempt ##{retries}] Retrying because [#{exception.class} - #{exception.message}]")
         end
         Retryable.configure do |retry_config|
           retry_config.log_method   = log_method
@@ -96,6 +96,7 @@ module Kitchen
         info("Linode <#{state[:linode_id]}, #{state[:hostname]}> ready.")
         setup_ssh(state) if bourne_shell?
       rescue Fog::Errors::Error, Excon::Errors::Error => ex
+        error("Failed to create server: #{ex.class} - #{ex.message}")
         raise ActionFailed, ex.message
       end
 

--- a/spec/kitchen/driver/linode_spec.rb
+++ b/spec/kitchen/driver/linode_spec.rb
@@ -144,13 +144,13 @@ describe Kitchen::Driver::Linode do
         }
       end
       let(:server) do
-        double(id: 'test123', wait_for: true, ipv4: %w(1.2.3.4))
+        double(id: 123456, wait_for: true, ipv4: %w(1.2.3.4), label: 'test123')
       end
 
       let(:driver) do
         d = described_class.new(config)
         allow(d).to receive(:create_server).and_return(server)
-        allow(server).to receive(:id).and_return('test123')
+        allow(server).to receive(:id).and_return(123456)
 
         allow(server).to receive(:wait_for)
           .with(an_instance_of(Fixnum)).and_yield
@@ -160,7 +160,8 @@ describe Kitchen::Driver::Linode do
 
       it 'returns nil, but modifies the state' do
         expect(driver.send(:create, state)).to eq(nil)
-        expect(state[:linode_id]).to eq('test123')
+        expect(state[:linode_id]).to eq(123456)
+        expect(state[:linode_label]).to eq('test123')
       end
 
       it 'throws an Action error when trying to create_server' do

--- a/spec/kitchen/driver/linode_spec.rb
+++ b/spec/kitchen/driver/linode_spec.rb
@@ -98,7 +98,8 @@ describe Kitchen::Driver::Linode do
           label: 'thisserver',
           private_key_path: '/path/to/id_rsa',
           public_key_path: '/path/to/id_rsa.pub',
-          password: 'somepassword'
+          password: 'somepassword',
+          api_retries: 2
         }
       end
 
@@ -143,7 +144,7 @@ describe Kitchen::Driver::Linode do
         }
       end
       let(:server) do
-        double(id: 'test123', wait_for: true, public_ip_address: %w(1.2.3.4))
+        double(id: 'test123', wait_for: true, ipv4: %w(1.2.3.4))
       end
 
       let(:driver) do


### PR DESCRIPTION
This wraps the API calls in a retry when the API connection returns a connect timeout or an HTTP status 408. By default it retries 3 times, that can be adjusted using the `api_retries` config option.

As well, now the code will check if another server is already using the label it wants, and if so it'll pick a different random suffix. Also added retry support if we do end up with a non-unique label on server create.

Added better error handling on deletes so a 404 doesn't make it nervous.

Signed-off-by: M. David Bennett <mdavidbennett@syntheticworks.com>